### PR TITLE
Rationalize (de)serialization of NumPy ndarrays

### DIFF
--- a/api/demos/benchmark.py
+++ b/api/demos/benchmark.py
@@ -4,8 +4,8 @@ import logging
 import numpy as np
 import requests
 
-from plot.custom_types import PlotMessage, asdict
-from plot.fastapi_utils import mp_packb
+from plot.custom_types import PlotMessage
+from plot.fastapi_utils import ws_pack
 
 
 def benchmark_plotting(points: int) -> requests.Response:
@@ -38,7 +38,7 @@ def benchmark_plotting(points: int) -> requests.Response:
         },
     )
 
-    msg = mp_packb(asdict(new_line))
+    msg = ws_pack(new_line)
     url = "http://localhost:8000/push_data"
     headers = {
         "Content-Type": "application/x-msgpack",

--- a/api/main.py
+++ b/api/main.py
@@ -10,7 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.routing import Mount
 
 from plot.custom_types import MsgType, PlotMessage, StatusType
-from plot.fastapi_utils import j_loads, message_unpack, ws_deserialize_ndarray
+from plot.fastapi_utils import message_unpack, ws_unpack
 from plot.plotserver import PlotServer
 
 app = FastAPI()
@@ -38,8 +38,8 @@ async def websocket(websocket: WebSocket, plot_id: str):
 
     try:
         while True:
-            message = await websocket.receive_text()
-            message = ws_deserialize_ndarray(j_loads(message))
+            message = await websocket.receive()
+            message = ws_unpack(message["bytes"])
             logging.debug(f"current message is {message}")
             received_message = PlotMessage(**message)
             if received_message.type == MsgType.status:

--- a/api/plot/utils.py
+++ b/api/plot/utils.py
@@ -9,15 +9,13 @@ from time import time_ns
 from typing import Union
 
 from plot.custom_types import (
-    asdict,
     HeatmapData,
     ImageData,
     LineData,
     MsgType,
     PlotMessage,
 )
-from plot.fastapi_utils import j_loads, j_dumps, mp_packb
-
+from plot.fastapi_utils import j_dumps, j_loads, ws_pack
 
 OptionalArrayLike = ArrayLike | None
 OptionalLists = Union[OptionalArrayLike, list[OptionalArrayLike], None]
@@ -35,11 +33,11 @@ class PlotConnection:
         if data is None:
             return None, None
         if self.use_msgpack:
-            data = mp_packb(asdict(data))
+            data = ws_pack(data)
             return data, {
                 "Content-Type": "application/x-msgpack",
             }
-        data = j_dumps(asdict(data))
+        data = j_dumps(data)
         return data, None
 
     def _post(self, params, msg_type=MsgType.new_multiline_data, endpoint="push_data"):

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,7 +1,6 @@
 fastapi==0.85.0
 httpx==0.23.0
 msgpack==1.0.4
-msgpack_numpy==0.4.8
 numpy==1.23.3
 orjson_pydantic==3.6.7
 pydantic_numpy==1.3.0

--- a/api/setup.py
+++ b/api/setup.py
@@ -13,7 +13,6 @@ setup(
     install_requires=[
         "fastapi",
         "httpx",
-        "msgpack-numpy",
         "orjson-pydantic",
         "pytest",
         "pytest-asyncio",

--- a/api/tests/test_plotserver.py
+++ b/api/tests/test_plotserver.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 
 from plot.custom_types import PlotMessage, StatusType, asdict
-from plot.fastapi_utils import mp_packb, mp_unpackb
+from plot.fastapi_utils import ws_pack, ws_unpack
 from plot.plotserver import PlotServer
 
 from .test_api import nppd_assert_equal
@@ -37,7 +37,7 @@ async def test_send_points():
     processed_line = ps.processor.process(new_line)
     line_as_dict = asdict(processed_line)
 
-    msg = mp_packb(line_as_dict)
+    msg = ws_pack(line_as_dict)
     ps.message_history["plot_0"].append(msg)
     assert not ps.clients_available()
 
@@ -51,5 +51,5 @@ async def test_send_points():
     assert ps.message_history == {"plot_0": [msg]}
     assert not ps.clients_available()
 
-    unpacked_msg = mp_unpackb(msg)
+    unpacked_msg = ws_unpack(msg)
     nppd_assert_equal(line_as_dict, unpacked_msg)

--- a/client/component/PlotComponent.tsx
+++ b/client/component/PlotComponent.tsx
@@ -1,6 +1,6 @@
 import '@h5web/lib/dist/styles.css';
 import { RgbVis, ScaleType } from '@h5web/lib';
-import {decode} from 'messagepack';
+import {decode, encode} from 'messagepack';
 import ndarray from 'ndarray';
 import React from 'react';
 import HeatPlot from './HeatPlot'
@@ -132,7 +132,7 @@ class PlotComponent extends React.Component<PlotComponentProps, PlotStates> {
         params: "ready",
         plot_config: {},
       };
-      this.socket.send(JSON.stringify(initStatus));
+      this.socket.send(encode(initStatus));
     };
     this.socket.onmessage = (event: MessageEvent) => {
       const decoded_message = decode(event.data) as LineDataMessage | MultiLineDataMessage
@@ -171,7 +171,7 @@ class PlotComponent extends React.Component<PlotComponentProps, PlotStates> {
           params: "ready",
           plot_config: {},
         };
-        this.socket.send(JSON.stringify(status));
+        this.socket.send(encode(status));
       }
     };
   }

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - requests
   - nodejs
   - numpy
-  - msgpack-numpy
   - pytest
   - pytest-asyncio
   - httpx


### PR DESCRIPTION
Make websocket use MessagePack bi-directionally, remove msgpack-numpy usage and use own NumPy to dict conversion