### PR TITLE
Fix event bubbling

### DIFF
--- a/client/component/shapes/DvdDragHandle.tsx
+++ b/client/component/shapes/DvdDragHandle.tsx
@@ -24,12 +24,14 @@ function Handle(props: HandleProps) {
       onPointerUp:
         drag &&
         ((e: PointerEvent) => {
+          e.stopPropagation();
           (e.target as Element).releasePointerCapture(e.pointerId);
           drag.dragEnd(e);
         }),
       onPointerDown:
         drag &&
         ((e: PointerEvent) => {
+          e.stopPropagation();
           (e.target as Element).setPointerCapture(e.pointerId);
           drag.dragStart(e);
         }),


### PR DESCRIPTION
Upstream changed how events are bubbled in [h5web/lib#1473](https://github.com/silx-kit/h5web/pull/1473) so stop propagating them on drag handles