### PR TITLE
Expand UI for colour bar domain and scatter point size

### DIFF
--- a/client/component/src/AnyPlot.tsx
+++ b/client/component/src/AnyPlot.tsx
@@ -230,6 +230,8 @@ interface HeatmapPlotProps extends ImagePlotProps {
  * @member {NdArray<TypedArray>} dataArray - The z data values for the scatter plot.
  * @member {Domain} domain - The domain of the z axis.
  * @member {DAxesParameters} axesParameters - The axes parameters.
+ * @member {number} [pointSize] - The size of data points.
+ * @member {(p: number) => void} [setPointSize] - Function to update data point size.
  * @member {ColorMap} [colourMap] - The colour map.
  */
 interface ScatterPlotProps extends PlotSelectionProps {
@@ -243,6 +245,10 @@ interface ScatterPlotProps extends PlotSelectionProps {
   domain: Domain;
   /** The axes parameters */
   axesParameters: DAxesParameters;
+  /** The size of the data points */
+  pointSize: number;
+  /** Function to update data point size */
+  setPointSize: (p: number) => void;
   /** The colour map (optional) */
   colourMap?: ColorMap;
 }

--- a/client/component/src/DomainConfig.tsx
+++ b/client/component/src/DomainConfig.tsx
@@ -3,6 +3,7 @@ import {
   DomainControls,
   DomainSlider,
   Histogram,
+  ScaleType,
   useSafeDomain,
   useVisDomain,
 } from '@h5web/lib';
@@ -80,7 +81,7 @@ interface DomainConfigProps {
   /** The custom domain */
   customDomain: CustomDomain;
   /** The type of the colour scale */
-  scaleType: ColorScaleType;
+  scaleType?: ColorScaleType;
   /** Handles custom domain change */
   onCustomDomainChange: (domain: CustomDomain) => void;
   /** Returns histogram params (optional) */
@@ -98,7 +99,11 @@ function DomainConfig(props: DomainConfigProps) {
   const { onCustomDomainChange, histogramFunction } = props;
 
   const visDomain = useVisDomain(customDomain, dataDomain);
-  const [safeDomain, errors] = useSafeDomain(visDomain, dataDomain, scaleType);
+  const [safeDomain, errors] = useSafeDomain(
+    visDomain,
+    dataDomain,
+    scaleType ?? ScaleType.Linear
+  );
 
   const [sliderDomain, setSliderDomain] = useState<Domain>(visDomain);
   useEffect(() => {
@@ -180,7 +185,7 @@ function DomainConfig(props: DomainConfigProps) {
             value={sliderDomain}
             safeVisDomain={safeDomain}
             dataDomain={dataDomain}
-            scaleType={scaleType}
+            scaleType={scaleType ?? ScaleType.Linear}
             errors={errors}
             isAutoMin={isAutoMin}
             isAutoMax={isAutoMax}
@@ -202,7 +207,7 @@ function DomainConfig(props: DomainConfigProps) {
           <Histogram
             dataDomain={dataDomain}
             value={sliderDomain}
-            scaleType={scaleType}
+            scaleType={scaleType ?? ScaleType.Linear}
             onChangeMin={(val) => onCustomDomainChange([val, customDomain[1]])}
             onChangeMax={(val) => onCustomDomainChange([customDomain[0], val])}
             {...histogram}

--- a/client/component/src/HeatmapPlot.tsx
+++ b/client/component/src/HeatmapPlot.tsx
@@ -102,7 +102,7 @@ function HeatmapPlot(props: HeatmapPlotProps) {
         dDomain={props.domain}
         dCustomDomain={customDomain}
         setDCustomDomain={setCustomDomain}
-        values={props.values.data}
+        dData={props.values.data}
         dScaleType={heatmapScaleType}
         setDScaleType={setHeatmapScaleType}
         colourMap={colourMap}

--- a/client/component/src/ImagePlot.tsx
+++ b/client/component/src/ImagePlot.tsx
@@ -67,7 +67,7 @@ function ImagePlot(props: ImagePlotProps) {
         setAspect={setAspect}
         selectionType={selectionType}
         setSelectionType={setSelectionType}
-        values={props.values.data}
+        dData={props.values.data}
         selections={props.selections}
         updateSelections={props.addSelection}
       />

--- a/client/component/src/LineConfig.tsx
+++ b/client/component/src/LineConfig.tsx
@@ -72,9 +72,11 @@ function LineConfig(props: LineConfigProps) {
     currentLine = lineData.find((s) => s.key === currentLineKey) ?? lineData[0];
   }
 
+  console.log('currentLineKey is ', currentLineKey);
   const modeless = [];
   if (currentLine !== null) {
     const cLine: DLineData = currentLine;
+    console.log('cLine is ', cLine);
     const colour = (cLine.line_params.colour ??
       ('defaultColour' in cLine ? cLine.defaultColour : '#000000')) as string;
 

--- a/client/component/src/LineConfig.tsx
+++ b/client/component/src/LineConfig.tsx
@@ -35,7 +35,7 @@ interface LineConfigProps {
   /** The current selections */
   lineData: DLineData[];
   /** Handles updating selections */
-  updateLineParams: (l: DLineData) => void;
+  updateLineParams: (d: DLineData) => void;
   /** The key of the current selection (optional) */
   currentLineKey: string | null;
   /** If the line config is shown */
@@ -72,11 +72,9 @@ function LineConfig(props: LineConfigProps) {
     currentLine = lineData.find((s) => s.key === currentLineKey) ?? lineData[0];
   }
 
-  console.log('currentLineKey is ', currentLineKey);
   const modeless = [];
   if (currentLine !== null) {
     const cLine: DLineData = currentLine;
-    console.log('cLine is ', cLine);
     const colour = (cLine.line_params.colour ??
       ('defaultColour' in cLine ? cLine.defaultColour : '#000000')) as string;
 

--- a/client/component/src/PlotToolbar.tsx
+++ b/client/component/src/PlotToolbar.tsx
@@ -105,7 +105,7 @@ function TitleConfigModal(props: TitleConfigModalProps) {
  * @param {Domain} [dDomain] - Domain value for the d-axis.
  * @param {CustomDomain} [dCustomDomain] - Custom domain value for the d-axis.
  * @param {(d: CustomDomain) => void} [setDCustomDomain] - Sets the custom domain value for the d-axis.
- * @param {TypedArray} [values] - Values.
+ * @param {TypedArray} [dData] - Data for the d-axis (optional).
  * @param {ColorScaleType} [dScaleType] - The color scale type for the d-axis.
  * @param {(s: ColorScaleType) => void} [setDScaleType] - Sets the color scale type for the d-axis.
  * @param {ColorMap} [colourMap] - The color map.
@@ -114,6 +114,7 @@ function TitleConfigModal(props: TitleConfigModalProps) {
  * @param {() => void} toggleInvertColourMap - A function that toggles the color map inversion.
  * @param {SelectionBase[]} [selections] - Selections.
  * @param {(s: SelectionBase | null, b?: boolean, c?: boolean ) => void} [updateSelections] - A function that updates the selections.
+ * @param {number} [scatterPointSize] - The size of scatter data points.
  * @param {reactNode} [children] - Any child components.
  */
 interface PlotToolbarProps {
@@ -173,8 +174,8 @@ interface PlotToolbarProps {
   dCustomDomain?: CustomDomain;
   /** A function that sets the custom domain value for the d-axis (optional) */
   setDCustomDomain?: (d: CustomDomain) => void;
-  /** Values (optional) */
-  values?: TypedArray;
+  /** Data for the d-axis (optional) */
+  dData?: TypedArray;
   /** A color scale type for the d-axis (optional) */
   dScaleType?: ColorScaleType;
   /** A function that sets the color scale type for the d-axis (optional) */
@@ -197,6 +198,10 @@ interface PlotToolbarProps {
   ) => void;
   lineData?: DLineData[];
   updateLineParams?: (p: DLineData) => void;
+  /** The size of scatter data points. */
+  scatterPointSize?: number;
+  /** A function that updates the selections (optional) */
+  setScatterPointSize?: (p: number) => void;
   /** Any child components (optional) */
   children?: ReactNode;
 }
@@ -390,7 +395,10 @@ function PlotToolbar(props: PlotToolbarProps) {
       domain: props.dDomain,
       customDomain: props.dCustomDomain,
       setCustomDomain: props.setDCustomDomain,
-      values: props.values,
+      dData: props.dData,
+      scatterPointSize: props.scatterPointSize,
+      setScatterPointSize: props.setScatterPointSize,
+      batonProps: props.batonProps,
     });
     a.forEach((m) => {
       if (m) bareModals.push(m);

--- a/client/component/src/ScatterPlot.tsx
+++ b/client/component/src/ScatterPlot.tsx
@@ -26,6 +26,7 @@ import type { MP_NDArray, ScatterPlotProps } from './AnyPlot';
  * @member {MP_NDArray} yData - The y data.
  * @member {MP_NDArray} dataArray - The z data.
  * @member {Domain} domain - The z data domain.
+ * @member {number} [pointSize] - The size of data points.
  * @member {ColorMap} [colourMap] - The colour map.
  */
 interface ScatterData {
@@ -39,6 +40,8 @@ interface ScatterData {
   dataArray: MP_NDArray;
   /** The z data domain */
   domain: Domain;
+  /** The size of the data points (optional) */
+  pointSize: number;
   /** The colour map */
   colourMap?: ColorMap;
 }
@@ -109,6 +112,7 @@ function ScatterPlot(props: ScatterPlotProps) {
         dDomain={props.domain}
         dCustomDomain={dCustomDomain}
         setDCustomDomain={setDCustomDomain}
+        dData={props.dataArray.data}
         colourMap={colourMap}
         setColourMap={setColourMap}
         invertColourMap={invertColourMap}
@@ -117,6 +121,8 @@ function ScatterPlot(props: ScatterPlotProps) {
         setSelectionType={setSelectionType}
         selections={props.selections}
         updateSelections={props.addSelection}
+        scatterPointSize={props.pointSize}
+        setScatterPointSize={props.setPointSize}
       />
       <ScatterVis
         abscissaParams={{
@@ -134,6 +140,7 @@ function ScatterPlot(props: ScatterPlotProps) {
           value: ordinateValue,
           scaleType: yScaleType,
         }}
+        size={props.pointSize}
         showGrid={showGrid}
         interactions={interactionsConfig}
       >

--- a/client/component/src/SurfacePlot.tsx
+++ b/client/component/src/SurfacePlot.tsx
@@ -81,7 +81,7 @@ function SurfacePlot(props: SurfacePlotProps) {
         dDomain={props.domain}
         dCustomDomain={customDomain}
         setDCustomDomain={setCustomDomain}
-        values={props.values.data}
+        dData={props.values.data}
         dScaleType={surfaceScaleType}
         setDScaleType={setSurfaceScaleType}
         colourMap={colourMap}

--- a/client/component/src/utils.test.ts
+++ b/client/component/src/utils.test.ts
@@ -291,6 +291,7 @@ describe('checks createDScatterData', () => {
         yData: b,
         dataArray: c,
         domain: [-4.7, 120],
+        pointSize: 15.5,
       } as ScatterData,
       {
         key: 'A',
@@ -299,6 +300,7 @@ describe('checks createDScatterData', () => {
         yData: e,
         dataArray: f,
         domain: [-4.7, 120],
+        pointSize: 15.5,
       } as DScatterData,
     ],
   ])(

--- a/client/component/src/utils.ts
+++ b/client/component/src/utils.ts
@@ -41,6 +41,7 @@ interface DScatterData {
   yData: NDT;
   dataArray: NDT;
   domain: [number, number];
+  pointSize: number;
   colourMap?: ColorMap;
 }
 
@@ -268,6 +269,7 @@ function createDScatterData(data: ScatterData): DScatterData {
     dataArray: i[0],
     domain: data.domain,
     colourMap: data.colourMap,
+    pointSize: data.pointSize,
   } as DScatterData;
 }
 
@@ -431,23 +433,23 @@ function createInteractionsConfig(
 }
 
 function createHistogramParams(
-  values: TypedArray | undefined,
+  dData: TypedArray | undefined,
   domain: Domain | undefined,
   colourMap: ColorMap | undefined,
   invertColourMap: boolean | undefined
 ): HistogramParams | undefined {
-  if (values && values.length != 0) {
+  if (dData && dData.length != 0) {
     const localBin = bin();
     const localScale =
       domain === undefined ? null : scaleLinear().domain(domain).nice();
-    const maxEdges = values.length;
+    const maxEdges = dData.length;
     let localEdges = null;
     if (localScale !== null && maxEdges > 0) {
       localEdges = localScale.ticks(Math.min(maxEdges, 20));
       localBin.thresholds(localEdges);
     }
 
-    const hist = localBin(values);
+    const hist = localBin(dData);
     const lengths = hist.map((b) => b.length);
     let edges;
     if (localEdges === null) {

--- a/server/davidia/models/messages.py
+++ b/server/davidia/models/messages.py
@@ -30,6 +30,7 @@ class MsgType(str, Enum):
     client_new_selection = "client_new_selection"
     client_update_selection = "client_update_selection"
     client_update_line_parameters = "client_update_line_parameters"
+    client_update_scatter_parameters = "client_update_scatter_parameters"
 
 
 class StatusType(str, Enum):
@@ -144,6 +145,7 @@ class ScatterData(NumpyModel):
     dataArray: DvDNDArray
     domain: tuple[float, float]
     colourMap: str
+    pointSize: float = 10
 
 
 class SurfaceData(NumpyModel):
@@ -284,6 +286,12 @@ class ClientLineParametersMessage(DataMessage):
 
     line_params: LineParams
     key: str
+
+
+class ClientScatterParametersMessage(DataMessage):
+    """Class for representing client scatter parameters"""
+
+    point_size: float
 
 
 class SelectionsMessage(SelectionMessage):

--- a/server/davidia/models/messages.py
+++ b/server/davidia/models/messages.py
@@ -107,6 +107,9 @@ class LineData(NumpyModel):
             values["default_indices"] = (
                 "y" not in values or "x" not in values or values["x"].size == 0
             )
+
+        if values.get("glyph_type") is None:
+            values["glyph_type"] = GlyphType.Circle
         return values
 
 

--- a/server/davidia/models/messages.py
+++ b/server/davidia/models/messages.py
@@ -1,4 +1,3 @@
-import random
 from enum import Enum
 from typing import Any
 from uuid import uuid4
@@ -108,15 +107,6 @@ class LineData(NumpyModel):
             values["default_indices"] = (
                 "y" not in values or "x" not in values or values["x"].size == 0
             )
-
-        if not values.get("key"):
-            values["key"] = f"_{random.randrange(1000)}"
-
-        if not values.get("name"):
-            values["name"] = values["key"]
-
-        if values.get("glyph_type") is None:
-            values["glyph_type"] = GlyphType.Circle
         return values
 
 
@@ -237,26 +227,6 @@ class MultiLineDataMessage(DataMessage):
         if len(v) > 0:
             return v
         raise ValueError("ml_data contains no LineData", v)
-
-    @field_validator("ml_data")
-    @classmethod
-    def line_keys_are_unique(cls, v):
-        keys = []
-        for line in v:
-            k = line.key
-            if k in keys:
-                new_key = f"_{random.randrange(1000)}"
-                line.key = new_key
-                if line.name == k:
-                    line.name = new_key
-                print(f"Duplicate line key {k} replaced with {new_key}")
-            else:
-                keys.append(k)
-
-        keys = [line.key for line in v]
-        if len(keys) != len(set(keys)):
-            raise ValueError("Duplicate keys remain", v)
-        return v
 
     @field_validator("ml_data")
     @classmethod

--- a/server/davidia/plot.py
+++ b/server/davidia/plot.py
@@ -603,6 +603,7 @@ def scatter(
     Keyword options for attribs are
     {
         "colourMap": str
+        "pointSize": float
     }
 
     Returns

--- a/server/davidia/server/processor.py
+++ b/server/davidia/server/processor.py
@@ -193,6 +193,8 @@ class Processor:
 
         params = check_line_names(params)
 
+        params = check_line_names(params)
+
         if append:
             return AppendLineDataMessage(
                 al_data=params, axes_parameters=axes_parameters

--- a/server/davidia/server/processor.py
+++ b/server/davidia/server/processor.py
@@ -4,6 +4,7 @@ from ..models.messages import (
     AppendLineDataMessage,
     AxesParameters,
     ClearSelectionsMessage,
+    ClientScatterParametersMessage,
     ClientSelectionMessage,
     ClientLineParametersMessage,
     HeatmapData,
@@ -148,6 +149,10 @@ class Processor:
                         else line
                     )
                 return ClientLineParametersMessage(key=key, line_params=params)
+            case MsgType.client_update_scatter_parameters:
+                if not isinstance(params, ClientScatterParametersMessage):
+                    point_size = params["point_size"]
+                return ClientScatterParametersMessage(point_size=point_size)
             case MsgType.new_selection_data:
                 if not isinstance(params, SelectionsMessage):
                     params = SelectionsMessage(
@@ -190,8 +195,6 @@ class Processor:
         MultiLineDataMessage | AppendLineDataMessage
             New multiline data message.
         """
-
-        params = check_line_names(params)
 
         params = check_line_names(params)
 


### PR DESCRIPTION
Adds UI to modify the colour bar domain and the scatter point size. For the scatter point size to be sent back to the server, there is a new ClientScatterParametersMessage type whcih currently only contains point_size but can be expanded later to include more parameters.