### PR TITLE
Fix active selection dashing

### DIFF
--- a/client/component/src/ConnectedPlot.tsx
+++ b/client/component/src/ConnectedPlot.tsx
@@ -406,7 +406,7 @@ function ConnectedPlot({
     broadcast = true,
     clear = false
   ) => {
-    const id = hUpdateSelection(selection, clear);
+    const id = hUpdateSelection(selection, broadcast, clear);
     if (broadcast) {
       if (clear) {
         sendClientMessage('clear_selection_data', {

--- a/client/component/src/PlotToolbar.tsx
+++ b/client/component/src/PlotToolbar.tsx
@@ -107,16 +107,18 @@ function PlotToolbar(props: PropsWithChildren): JSX.Element {
           const last = selections[selections.length - 1];
           console.log('Setting current selection', last.id);
           setCurrentSelectionID(last.id);
-          enableSelection(last);
+          if (showSelectionConfig) {
+            enableSelection(last);
+          }
         }
-      } else {
+      } else if (showSelectionConfig) {
         const selection = selections.find((s) => s.id === currentSelectionID);
         if (selection) {
           enableSelection(selection);
         }
       }
     }
-  }, [canSelect, currentSelectionID, selections]);
+  }, [canSelect, currentSelectionID, selections, showSelectionConfig]);
 
   const isLine = plotType === 'Line';
   const isHeatmap = plotType === 'Heatmap';

--- a/client/component/src/selections/utils.tsx
+++ b/client/component/src/selections/utils.tsx
@@ -592,7 +592,7 @@ function useSelections(initSelections?: SelectionBase[]) {
  * Set fixed and asDashed properties of selection to false.
  * @param {SelectionBase} s - The selection to modify.
  */
-function enableSelection(s: SelectionBase) {
+function disableSelection(s: SelectionBase) {
   s.fixed = false;
   s.asDashed = false;
 }
@@ -601,7 +601,7 @@ function enableSelection(s: SelectionBase) {
  * Set fixed and asDashed properties of selection to true.
  * @param {SelectionBase} s - The selection to modify.
  */
-function disableSelection(s: SelectionBase) {
+function enableSelection(s: SelectionBase) {
   s.fixed = true;
   s.asDashed = true;
 }


### PR DESCRIPTION
Show active selection as dashed without handles when selection config open.
Restore previous definition of enableSelections.