### PR TITLE
Update open selection config

### DIFF
--- a/client/component/src/AxialSelectionConfig.tsx
+++ b/client/component/src/AxialSelectionConfig.tsx
@@ -29,12 +29,13 @@ function AxialSelectionConfig(props: AxialSelectionConfigProps) {
   return selection.dimension === 0 ? (
     <Fragment key="axis x">
       <XInput
+        key={`XInput${selection.vStart.x}`}
         selection={selection}
         updateSelection={updateSelection}
         disabled={disabled}
       />
       <LabelledInput<number>
-        key="x length"
+        key={`XLength${selection.length}`}
         label="x length"
         input={selection.length}
         updateValue={(l: number) => {
@@ -51,12 +52,13 @@ function AxialSelectionConfig(props: AxialSelectionConfigProps) {
   ) : (
     <Fragment key="axis y">
       <YInput
+        key={`YInput${selection.vStart.y}`}
         selection={selection}
         updateSelection={updateSelection}
         disabled={disabled}
       />
       <LabelledInput<number>
-        key="y length"
+        key={`YLength${selection.length}`}
         label="y length"
         input={selection.length}
         updateValue={(l: number) => {

--- a/client/component/src/LabelledInput.tsx
+++ b/client/component/src/LabelledInput.tsx
@@ -134,7 +134,7 @@ function LabelledInput<T>(props: LabelledInputProps<T>) {
           {props.label}:
         </label>
         {resetButton && (
-          <button onClick={handleReset}>
+          <button onClick={handleReset} disabled={props.disabled}>
             <IoMdUndo />
           </button>
         )}

--- a/client/component/src/LinearSelectionConfig.tsx
+++ b/client/component/src/LinearSelectionConfig.tsx
@@ -28,25 +28,28 @@ function LinearSelectionConfig(props: LinearSelectionConfigProps) {
   return (
     <Fragment key="line">
       <XInput
+        key={`XInput${selection.vStart.x}`}
         selection={selection}
         updateSelection={updateSelection}
         disabled={disabled}
       />
 
       <YInput
+        key={`YInput${selection.vStart.y}`}
         selection={selection}
         updateSelection={updateSelection}
         disabled={disabled}
       />
 
       <AngleInput
+        key={`Angle${selection.angle}`}
         selection={selection}
         updateSelection={updateSelection}
         disabled={disabled}
       />
 
       <LabelledInput<number>
-        key="length"
+        key={`Length${selection.length}`}
         label="length"
         input={selection.length}
         updateValue={(l: number) => {

--- a/client/component/src/PlotToolbar.tsx
+++ b/client/component/src/PlotToolbar.tsx
@@ -30,7 +30,7 @@ import LineKeyDropdown from './LineKeyDropdown';
 import type { IIconType } from './Modal';
 import Modal from './Modal';
 import SelectionTypeDropdown from './SelectionTypeDropdown';
-import { disableSelection, dashSelection } from './selections/utils';
+import { undashSelection, dashSelection } from './selections/utils';
 import SelectionConfig from './SelectionConfig';
 import SelectionIDDropdown from './SelectionIDDropdown';
 import { InteractionModeType } from './utils';
@@ -101,7 +101,7 @@ function PlotToolbar(props: PropsWithChildren): JSX.Element {
 
   useEffect(() => {
     if (canSelect) {
-      selections.map((s) => disableSelection(s));
+      selections.map((s) => undashSelection(s));
       if (currentSelectionID === null) {
         if (selections.length > 0) {
           const last = selections[selections.length - 1];
@@ -286,7 +286,6 @@ function PlotToolbar(props: PropsWithChildren): JSX.Element {
           setCurrentSelectionID(i);
           if (canSelect) {
             updateSelection(selection);
-            console.log('updated selections: ', selections);
           }
         }
         setShowSelectionConfig(true);

--- a/client/component/src/PlotToolbar.tsx
+++ b/client/component/src/PlotToolbar.tsx
@@ -30,7 +30,7 @@ import LineKeyDropdown from './LineKeyDropdown';
 import type { IIconType } from './Modal';
 import Modal from './Modal';
 import SelectionTypeDropdown from './SelectionTypeDropdown';
-import { disableSelection, enableSelection } from './selections/utils';
+import { disableSelection, dashSelection } from './selections/utils';
 import SelectionConfig from './SelectionConfig';
 import SelectionIDDropdown from './SelectionIDDropdown';
 import { InteractionModeType } from './utils';
@@ -87,11 +87,11 @@ function PlotToolbar(props: PropsWithChildren): JSX.Element {
       : null;
   }, [canSelect, selections]);
   useEffect(() => {
-    if (firstSelection) {
+    if (firstSelection && currentSelectionID === null) {
       console.log('Setting first selection', firstSelection);
       setCurrentSelectionID(firstSelection);
     }
-  }, [firstSelection]);
+  }, [firstSelection, currentSelectionID]);
 
   const [showSelectionConfig, setShowSelectionConfig] = useState(false);
   const [showLineConfig, setShowLineConfig] = useState(false);
@@ -108,13 +108,13 @@ function PlotToolbar(props: PropsWithChildren): JSX.Element {
           console.log('Setting current selection', last.id);
           setCurrentSelectionID(last.id);
           if (showSelectionConfig) {
-            enableSelection(last);
+            dashSelection(last);
           }
         }
       } else if (showSelectionConfig) {
         const selection = selections.find((s) => s.id === currentSelectionID);
         if (selection) {
-          enableSelection(selection);
+          dashSelection(selection);
         }
       }
     }

--- a/client/component/src/PolygonalSelectionConfig.tsx
+++ b/client/component/src/PolygonalSelectionConfig.tsx
@@ -39,14 +39,14 @@ function PolygonalSelectionConfig(props: PolygonalSelectionConfigProps) {
   const xyInputs = selection.points.map((p, i) => {
     return [
       <PointXInput
-        key={`px${i}`}
+        key={`px${i}${p[0]}`}
         i={i}
         point={p}
         updatePoint={(np) => updatePoint(np, i)}
         disabled={disabled}
       />,
       <PointYInput
-        key={`py${i}`}
+        key={`py${i}${p[1]}`}
         i={i}
         point={p}
         updatePoint={(np) => updatePoint(np, i)}

--- a/client/component/src/RectangularSelectionConfig.tsx
+++ b/client/component/src/RectangularSelectionConfig.tsx
@@ -28,25 +28,28 @@ function RectangularSelectionConfig(props: RectangularSelectionConfigProps) {
   return (
     <Fragment key="rectangle">
       <XInput
+        key={`XInput${selection.vStart.x}`}
         selection={selection}
         updateSelection={updateSelection}
         disabled={disabled}
       />
 
       <YInput
+        key={`YInput${selection.vStart.y}`}
         selection={selection}
         updateSelection={updateSelection}
         disabled={disabled}
       />
 
       <AngleInput
+        key={`Angle${selection.angle}`}
         selection={selection}
         updateSelection={updateSelection}
         disabled={disabled}
       />
 
       <LabelledInput<number>
-        key="x length"
+        key={`XLength${selection.lengths[0]}`}
         label="x length"
         input={selection.lengths[0]}
         updateValue={(l: number) => {
@@ -61,7 +64,7 @@ function RectangularSelectionConfig(props: RectangularSelectionConfigProps) {
       />
 
       <LabelledInput<number>
-        key="y length"
+        key={`YLength${selection.lengths[1]}`}
         label="y length"
         input={selection.lengths[1]}
         updateValue={(l: number) => {

--- a/client/component/src/selections/utils.tsx
+++ b/client/component/src/selections/utils.tsx
@@ -589,16 +589,15 @@ function useSelections(initSelections?: SelectionBase[]) {
 }
 
 /**
- * Set fixed and asDashed properties of selection to false.
+ * Set asDashed property of selection to false.
  * @param {SelectionBase} s - The selection to modify.
  */
-function disableSelection(s: SelectionBase) {
-  s.fixed = false;
+function undashSelection(s: SelectionBase) {
   s.asDashed = false;
 }
 
 /**
- * Set fixed and asDashed properties of selection to true.
+ * Set asDashed property of selection to true.
  * @param {SelectionBase} s - The selection to modify.
  */
 function dashSelection(s: SelectionBase) {
@@ -619,7 +618,7 @@ export {
   useSelections,
   SelectionType,
   dashSelection,
-  disableSelection,
+  undashSelection,
 };
 
 export type { HandleChangeFunction, SelectionBase, SelectionHandler };

--- a/client/component/src/selections/utils.tsx
+++ b/client/component/src/selections/utils.tsx
@@ -601,8 +601,7 @@ function disableSelection(s: SelectionBase) {
  * Set fixed and asDashed properties of selection to true.
  * @param {SelectionBase} s - The selection to modify.
  */
-function enableSelection(s: SelectionBase) {
-  s.fixed = true;
+function dashSelection(s: SelectionBase) {
   s.asDashed = true;
 }
 
@@ -619,7 +618,7 @@ export {
   validateHtml,
   useSelections,
   SelectionType,
-  enableSelection,
+  dashSelection,
   disableSelection,
 };
 


### PR DESCRIPTION
When selections are updated, an open `SelectionConfig` now updates. Current selections have drag handles in the baton holder when open in `SelectionConfig`. When drawing a new selection, `currentSelectionID` is not automatically updated. 