### PR TITLE
Allow downstream to avoid invalid hook issues with multiple React versions

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -33,7 +33,7 @@ module.exports = {
   },
   settings: {
     react: {
-      version: '17',
+      version: '18',
     },
   },
 };

--- a/client/component/package.json
+++ b/client/component/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/DiamondLightSource/davidia.git"
   },
   "private": false,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "build": "tsc && vite build",
@@ -23,10 +23,7 @@
     "types": "dist/index.d.ts"
   },
   "dependencies": {
-    "@h5web/lib": "^13.0.0",
     "@react-hookz/web": "^24.0.4",
-    "@react-three/drei": "^9.111.2",
-    "@react-three/fiber": "^8.17.5",
     "@visx/drag": "^3.3.0",
     "afterframe": "^1.0.2",
     "buffer": "^6.0.3",
@@ -35,21 +32,29 @@
     "d3-format": "^3.1.0",
     "d3-scale": "^4.0.2",
     "messagepack": "^1.1.12",
-    "ndarray": "^1.0.19",
     "ndarray-concat-rows": "^1.0.1",
     "ndarray-linspace": "^2.0.3",
-    "react": "^18.3.1",
     "react-colorful": "^5.6.1",
-    "react-dom": "^18.3.1",
     "react-draggable": "^4.4.6",
     "react-icons": "^5.3.0",
     "react-select": "^5.8.0",
-    "react-toastify": "^9.1.3",
     "react-use-websocket": "^4.8.1",
-    "three": "^0.167.1",
     "websocket": "^1.0.35"
   },
+  "peerDependencies": {
+    "@h5web/lib": "^13.0.0",
+    "@react-three/drei": "^9.111.2",
+    "@react-three/fiber": "^8.17.5",
+    "ndarray": "^1.0.19",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-toastify": "^9.1.3",
+    "three": "^0.167.1"
+  },
   "devDependencies": {
+    "@h5web/lib": "^13.0.0",
+    "@react-three/drei": "^9.111.2",
+    "@react-three/fiber": "^8.17.5",
     "@types/cwise": "^1.0.6",
     "@types/d3-array": "^3.2.1",
     "@types/d3-format": "^3.0.4",
@@ -61,6 +66,11 @@
     "@types/three": "^0.164.1",
     "@types/websocket": "^1.0.10",
     "d3-random": "^3.0.1",
+    "ndarray": "^1.0.19",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-toastify": "^9.1.3",
+    "three": "^0.167.1",
     "typedoc": "^0.25.13",
     "vite-plugin-dts": "^3.9.1",
     "vitest": "^1.6.0"

--- a/client/component/vite.config.ts
+++ b/client/component/vite.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
+import fs from 'fs';
 import { resolve } from 'path';
+import react from '@vitejs/plugin-react';
+
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+
+export const externals = [
+  ...Object.keys(pkg.dependencies),
+  ...Object.keys(pkg.peerDependencies),
+];
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -11,6 +19,10 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       formats: ['es'],
       fileName: 'index',
+    },
+    rollupOptions: {
+      external: externals.map((dep) => new RegExp(`^${dep}($|\\/)`, 'u')), // e.g. externalize `react-icons/fi`
+      output: { interop: 'compat' }, // for compatibility with Jest in consumer projects (default changed in Rollup 3/Vite 4: https://rollupjs.org/migration/#changed-defaults)
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,18 +53,9 @@ importers:
 
   client/component:
     dependencies:
-      '@h5web/lib':
-        specifier: ^13.0.0
-        version: 13.0.0(@react-three/fiber@8.17.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.167.1))(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.167.1)(typescript@5.4.5)
       '@react-hookz/web':
         specifier: ^24.0.4
         version: 24.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-three/drei':
-        specifier: ^9.111.2
-        version: 9.111.2(@react-three/fiber@8.17.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.167.1))(@types/react@18.3.4)(@types/three@0.164.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.167.1)
-      '@react-three/fiber':
-        specifier: ^8.17.5
-        version: 8.17.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.167.1)
       '@visx/drag':
         specifier: ^3.3.0
         version: 3.3.0(react@18.3.1)
@@ -89,24 +80,15 @@ importers:
       messagepack:
         specifier: ^1.1.12
         version: 1.1.12
-      ndarray:
-        specifier: ^1.0.19
-        version: 1.0.19
       ndarray-concat-rows:
         specifier: ^1.0.1
         version: 1.0.1
       ndarray-linspace:
         specifier: ^2.0.3
         version: 2.0.3
-      react:
-        specifier: ^18.3.1
-        version: 18.3.1
       react-colorful:
         specifier: ^5.6.1
         version: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
       react-draggable:
         specifier: ^4.4.6
         version: 4.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -116,19 +98,22 @@ importers:
       react-select:
         specifier: ^5.8.0
         version: 5.8.0(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-toastify:
-        specifier: ^9.1.3
-        version: 9.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-use-websocket:
         specifier: ^4.8.1
         version: 4.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      three:
-        specifier: ^0.167.1
-        version: 0.167.1
       websocket:
         specifier: ^1.0.35
         version: 1.0.35
     devDependencies:
+      '@h5web/lib':
+        specifier: ^13.0.0
+        version: 13.0.0(@react-three/fiber@8.17.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.167.1))(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.167.1)(typescript@5.4.5)
+      '@react-three/drei':
+        specifier: ^9.111.2
+        version: 9.111.2(@react-three/fiber@8.17.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.167.1))(@types/react@18.3.4)(@types/three@0.164.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.167.1)
+      '@react-three/fiber':
+        specifier: ^8.17.5
+        version: 8.17.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.167.1)
       '@types/cwise':
         specifier: ^1.0.6
         version: 1.0.6
@@ -162,6 +147,21 @@ importers:
       d3-random:
         specifier: ^3.0.1
         version: 3.0.1
+      ndarray:
+        specifier: ^1.0.19
+        version: 1.0.19
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+      react-toastify:
+        specifier: ^9.1.3
+        version: 9.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      three:
+        specifier: ^0.167.1
+        version: 0.167.1
       typedoc:
         specifier: ^0.25.13
         version: 0.25.13(typescript@5.4.5)


### PR DESCRIPTION
Use peerDependencies in the component package to allow downstream to access react, three.js and @h5web/lib. Also update react version in lint config