### PR TITLE
Fix paths for types and css in npm package build

### DIFF
--- a/client/component/package.json
+++ b/client/component/package.json
@@ -18,12 +18,14 @@
   "files": [
     "dist"
   ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
-  },
-  "publishConfig": {
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./index.css": "./dist/index.css"
   },
   "dependencies": {
     "@msgpack/msgpack": "^3.1.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,15 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "typeRoots": [ "client/types" ],
+    "baseUrl": ".",
     "paths": {
-      "ndarray-concat-rows": ["./client/types/ndarray-concat-rows"]
+      "ndarray-concat-rows": ["./client/types/ndarray-concat-rows"],
+        "@diamondlightsource/davidia": [
+          "client/component/src/index.ts"
+        ],
+        "@diamondlightsource/davidia/index.css": [
+          "client/component/src/index.css"
+        ]
     },
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
Types were not being imported correctly in consumer apps. This PR:
- Publishes built library from dist rather than src
- Adds explicit export of css bundle